### PR TITLE
Fix: Remove extra left margin on "Explore Hackathons" page to elimina…

### DIFF
--- a/app/(dashboard)/(routes)/hackathons/page.tsx
+++ b/app/(dashboard)/(routes)/hackathons/page.tsx
@@ -70,7 +70,7 @@ const Page = () => {
     <div className='min-h-screen w-full text-black dark:bg-background bg-background dark:text-white mb-20 '>
       <div className='w-full mt-16 flex flex-col justify-start items-start gap-5'>
 
-        <div className=" md:ml-10 w-full flex justify-center items-center md:justify-start ">
+        <div className=" w-full flex justify-center items-center md:justify-start ">
           <div className="flex justify-center items-center md:items-start space-x-4 mx-auto w-full ">
             {platforms.map((platform) => (
               <motion.button


### PR DESCRIPTION
This commit addresses an issue on the "Explore Hackathons" page where an excessive left margin on larger screens was causing unnecessary horizontal scrolling. The `md:ml-10` class has been removed from the relevant div to ensure that the layout is properly aligned and adjusts to the screen size without additional margins. This improvement enhances the overall user experience on desktop devices.
